### PR TITLE
chore: update environment and Docker configuration for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ SQLITE_PATH=server/data/dsabrew.db
 # Nur lokal bei Hänger beim SQLite-Open: frische DB in /tmp (keine Persistenz über Neustarts)
 # DSABREW_USE_TEMP_SQLITE=1
 PUBLIC_ORIGIN=https://brew.rath-ulrich.de
+# Docker-Prod (Traefik-Host im Compose): nur Hostname, z. B. brew.rath-ulrich.de — siehe deploy/docker-compose.prod.yml
+# BREW_HOST=brew.rath-ulrich.de
 TRUST_PROXY=1
 RATE_POST_CREATE_PER_HOUR=10
 RATE_PUT_PER_HOUR=120

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - com.rathch.service=api
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK:-proxy}
-      - traefik.http.routers.dsabrew-api.rule=(Host("${DSABREW_HOST:-dsabrew.rath-ulrich.de}") || Host("${BREW_HOST:-brew.rath-ulrich.de}")) && PathPrefix(`/api`)
+      - traefik.http.routers.dsabrew-api.rule=Host(`${BREW_HOST:-brew.rath-ulrich.de}`) && PathPrefix(`/api`)
       - traefik.http.routers.dsabrew-api.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}
       - traefik.http.routers.dsabrew-api.tls=true
       - traefik.http.routers.dsabrew-api.tls.certresolver=${TRAEFIK_CERTRESOLVER:-letsencrypt}
@@ -34,10 +34,11 @@ services:
       - com.rathch.service=web
       - traefik.enable=true
       - traefik.docker.network=${TRAEFIK_NETWORK:-proxy}
-      - traefik.http.routers.dsabrew-web.rule=Host("${DSABREW_HOST:-dsabrew.rath-ulrich.de}") || Host("${BREW_HOST:-brew.rath-ulrich.de}")
+      - traefik.http.routers.dsabrew-web.rule=Host(`${BREW_HOST:-brew.rath-ulrich.de}`)
       - traefik.http.routers.dsabrew-web.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}
       - traefik.http.routers.dsabrew-web.tls=true
       - traefik.http.routers.dsabrew-web.tls.certresolver=${TRAEFIK_CERTRESOLVER:-letsencrypt}
+      - traefik.http.routers.dsabrew-web.tls.domains[0].main=${BREW_HOST:-brew.rath-ulrich.de}
       - traefik.http.routers.dsabrew-web.priority=10
       - traefik.http.services.dsabrew-web.loadbalancer.server.port=80
     networks:


### PR DESCRIPTION
- Added BREW_HOST variable to .env.example for Docker production setup.
- Simplified Traefik routing rules in docker-compose.prod.yml to use BREW_HOST directly.
- Specified TLS domain for dsabrew-web service in docker-compose.prod.yml.